### PR TITLE
Draft #2

### DIFF
--- a/srfi-258.html
+++ b/srfi-258.html
@@ -303,12 +303,20 @@ SPDX-License-Identifier: MIT
           <td class="yes">Yes</td>
         </tr>
         <tr>
+          <td>Gauche</td>
+          <td class="yes">Yes</td>
+          <td class="yes">Yes</td>
+          <td>String</td>
+          <td>No</td>
+          <td class="yes">Yes</td>
+        </tr>
+        <tr>
           <td>Guile</td>
           <td class="yes">Yes</td>
           <td class="yes">Yes</td>
           <td>String</td>
           <td>Yes</td>
-          <td class="no">No</td>
+          <td class="no">No*</td>
         <tr>
           <td>Ikarus</td>
           <td class="no">No</td>
@@ -320,7 +328,7 @@ SPDX-License-Identifier: MIT
         <tr>
           <td>Kawa</td>
           <td class="no">No</td>
-          <td class="no">No*</td>
+          <td class="no">No†</td>
           <td>n/a</td>
           <td>n/a</td>
           <td class="no">No</td>
@@ -344,7 +352,7 @@ SPDX-License-Identifier: MIT
         <tr>
           <td>MIT/GNU Scheme</td>
           <td class="yes">Yes</td>
-          <td class="no">No†</td>
+          <td class="no">No‡</td>
           <td>n/a</td>
           <td>n/a</td>
           <td class="yes">Yes</td>
@@ -367,12 +375,15 @@ SPDX-License-Identifier: MIT
       </tbody>
     </table>
 
-    <p>*: Kawa includes a
+    <p>*: Guile’s <code>make-symbol</code> procedure is identical to
+    <code>string-&gt;uninterned-symbol</code>.</p>
+
+    <p>†: Kawa includes a
     <a href="https://www.gnu.org/software/kawa/Macros.html#idm45230724012608">
     zero-argument <code>gentemp</code> procedure</a> that returns an interned
     symbol.</p>
 
-    <p>†: MIT/GNU Scheme provides
+    <p>‡: MIT/GNU Scheme provides
     <a href="https://web.mit.edu/scheme/scheme_v9.2/doc/mit-scheme-ref/Symbols.html">generate-uninterned-symbol</a>,
     an extended version of
     <a href="#generate-uninterned-symbol">the procedure described

--- a/srfi-258.html
+++ b/srfi-258.html
@@ -53,9 +53,7 @@ SPDX-License-Identifier: MIT
     <p>An uninterned symbol is not the same as any other symbol, even one
     with the same name. These symbols are useful in macro programming and
     in other situations where guaranteed-unique names are needed.
-    A lexical syntax for uninterned symbols is described, allowing
-    uninterned literal symbols to appear in program source and macro
-    templates. A survey of uninterned and uniquely-named symbols
+    A survey of uninterned and uniquely-named symbols
     in Scheme is also provided.</p>
 
     <h2 id="table-of-contents">Table of Contents</h2>
@@ -82,7 +80,6 @@ SPDX-License-Identifier: MIT
           </li>
         </ul>
       </li>
-      <li><a href="#lexical-syntax">Lexical syntax</a></li>
       <li>
         <a href="#prior-art">Prior art</a>
         <ul>
@@ -203,43 +200,6 @@ SPDX-License-Identifier: MIT
     Unique Identifiers (UUIDs) (ITU-T Rec. X.667, ISO/IEC
     9834-8:2014) as names.</p>
 
-
-    <h2 id="lexical-syntax">Lexical syntax</h2>
-
-    <p>Uninterned symbols are written using the notation
-    <code>:|</code><var class="syn">identifier</var><code>|</code>, where
-    <var class="syn">identifier</var> belongs to the class of valid Scheme
-    identifiers defined in <cite>R7RS</cite> § 7.1.1. Example:</p>
-
-    <pre class="example"><code>(symbol-&gt;string :|srfi|)</code> ⇒ <code>"srfi"
-(symbol-interned? ':|srfi|)</code> ⇒ <code>#f</code></pre>
-
-    <p>More formally, this SRFI extends the syntax of Scheme as described
-    in § 7.1 of the <cite>R7RS</cite> as follows. The following
-    production is added to § 7.1.1:</p>
-
-    <pre class="grammar"><var class="syn">uninterned symbol</var> ⟶ <code>:|</code> <var class="syn">identifier</var> <code>|</code></pre>
-
-    <p>The following production of § 7.1.2 is extended:</p>
-
-    <pre class="grammar"><var class="syn">simple datum</var> ⟶ <var class="syn">boolean</var> | … | <var class="syn">uninterned symbol</var></pre>
-
-    <p>And in § 7.1.5:</p>
-
-    <pre class="grammar"><var class="syn">pattern datum</var> ⟶ <var class="syn">boolean</var> | … | <var class="syn">uninterned symbol</var></pre>
-
-    <h4>Rationale:</h4>
-
-    <p>The <code>:|</code>…<code>|</code> syntax was chosen for its
-    similarity to R7RS’s lexical syntax for identifiers and to Common
-    Lisp’s keyword syntax.</p>
-
-    <p>Most implementations that provide uninterned symbols do not
-    offer lexical syntax for them, so there is little prior art to go
-    on here. <a href="#chezscheme">ChezScheme</a> has lexical syntax
-    for its gensyms, but, since these are special interned symbols, it
-    would create unnecessary incompatibility to use Chez’s syntax for
-    uninterned symbols.</p>
 
     <h2 id="prior-art">Prior art</h2>
 

--- a/srfi-258.html
+++ b/srfi-258.html
@@ -169,6 +169,9 @@ SPDX-License-Identifier: MIT
 
     <h2 id="procedures">Procedures</h2>
 
+    <p>The procedures in this section are exported by the
+    <code>(srfi :258 uninterned-symbols)</code> library.</p>
+
     <p id="string-to-uninterned-symbol">
     <code>(string-&gt;uninterned-symbol</code> <var>string</var><code>)</code>
     → <span class="type-meta">uninterned-symbol</span></p>

--- a/srfi-258.html
+++ b/srfi-258.html
@@ -212,7 +212,7 @@ SPDX-License-Identifier: MIT
     identifiers defined in <cite>R7RS</cite> § 7.1.1. Example:</p>
 
     <pre class="example"><code>(symbol-&gt;string :|srfi|)</code> ⇒ <code>"srfi"
-(symbol-interned? :|srfi|)</code> ⇒ <code>#f</code></pre>
+(symbol-interned? ':|srfi|)</code> ⇒ <code>#f</code></pre>
 
     <p>More formally, this SRFI extends the syntax of Scheme as described
     in § 7.1 of the <cite>R7RS</cite> as follows. The following
@@ -224,10 +224,6 @@ SPDX-License-Identifier: MIT
 
     <pre class="grammar"><var class="syn">simple datum</var> ⟶ <var class="syn">boolean</var> | … | <var class="syn">uninterned symbol</var></pre>
 
-    <p>Similarly, in § 7.1.3:</p>
-
-    <pre class="grammar"><var class="syn">self-evaluating</var> ⟶ <var class="syn">boolean</var> | … | <var class="syn">uninterned symbol</var></pre>
-
     <p>And in § 7.1.5:</p>
 
     <pre class="grammar"><var class="syn">pattern datum</var> ⟶ <var class="syn">boolean</var> | … | <var class="syn">uninterned symbol</var></pre>
@@ -236,8 +232,7 @@ SPDX-License-Identifier: MIT
 
     <p>The <code>:|</code>…<code>|</code> syntax was chosen for its
     similarity to R7RS’s lexical syntax for identifiers and to Common
-    Lisp’s keyword syntax (like CL’s keywords, uninterned symbols are
-    “self-quoting”).</p>
+    Lisp’s keyword syntax.</p>
 
     <p>Most implementations that provide uninterned symbols do not
     offer lexical syntax for them, so there is little prior art to go

--- a/srfi-258.html
+++ b/srfi-258.html
@@ -153,11 +153,13 @@ SPDX-License-Identifier: MIT
     <code>string-&gt;uninterned-symbol</code> or
     <code>generate-uninterned-symbol</code>.</p>
 
-    <p>Uninterned symbols do not support the write/read invariants
-    described in <cite>R7RS</cite> section 6.5: if an uninterned symbol is
-    written out with <code>write</code> and then read back in, the
-    resulting symbol is not identical (in the sense of
-    <code>symbol=?</code>) to the original symbol.</p>
+    <p>The exact external representation of an uninterned symbol is
+    unspecified, but the <code>read</code> procedure (<cite>R7RS</cite>
+    section 6.13.2) must signal an error (satisfying
+    <code>read-error?</code>) if it encounters such an external
+    representation. Thus uninterned symbols do not support the
+    write/read invariance described in <cite>R7RS</cite> section
+    6.5.</p>
 
 
     <h2 id="procedures">Procedures</h2>

--- a/srfi-258.html
+++ b/srfi-258.html
@@ -138,6 +138,11 @@ SPDX-License-Identifier: MIT
 
     <h2 id="specification">Specification</h2>
 
+    <p>The words “must”, “may”, etc., though not capitalized in this
+    SRFI, are to be interpreted as described in
+    <a href="https://datatracker.ietf.org/doc/html/rfc2119">RFC
+    2119</a>.</p>
+
     <p>In this document, a symbol’s <dfn>textual name</dfn> refers to
     the string returned when <code>symbol-&gt;string</code> is invoked
     on the symbol.</p>
@@ -436,6 +441,10 @@ SPDX-License-Identifier: MIT
     <p>Cisco Systems, Inc., <cite>Chez Scheme User’s Guide</cite> (2015).
     Available <a href="https://cisco.github.io/ChezScheme/csug9.5">on the
     Web</a>.</p>
+
+    <p>S. Bradner, <cite>Key words for use in RFCs to Indicate Requirement
+    Levels</cite>. (RFC 2119) (1997).
+    https://datatracker.ietf.org/doc/html/rfc2119</p>
 
 
     <h2 id="copyright">Copyright</h2>

--- a/srfi-258.sls
+++ b/srfi-258.sls
@@ -5,7 +5,7 @@
 
 ;;; Wrapper implementation for ChezScheme.
 
-(library (uninterned-symbols)
+(library (srfi :258 uninterned-symbols)
   (export string->uninterned-symbol symbol-interned?
           generate-uninterned-symbol)
   (import (rnrs base)


### PR DESCRIPTION
This draft removes the lexical syntax for uninterned symbols. Attempting to read an external representation of an uninterned symbol is now an error.

Thanks for merging!