### PR TITLE
remove space before closing parenthesis

### DIFF
--- a/srfi-258.html
+++ b/srfi-258.html
@@ -179,8 +179,8 @@ SPDX-License-Identifier: MIT
 
     <p>Returns an uninterned symbol with a textual name given by <var>string</var>.</p>
 
-    <p id="symbol-interned"><code>(symbol-interned?</code> <var>symbol</var>
-    <code>)</code> → <span class="type-meta">boolean</span></p>
+    <p id="symbol-interned"><code>(symbol-interned?</code> <var>symbol</var><code>)</code>
+    → <span class="type-meta">boolean</span></p>
 
     <p>Returns <code>#t</code> if <var>symbol</var> is an interned (ordinary)
     symbol, and <code>#f</code> if it is uninterned.</p>


### PR DESCRIPTION
This is a fix for the minor technical issue:

the rendered HTML shows:

```
(symbol-interned? symbol ) → boolean
```

but it should be:


```
(symbol-interned? symbol) → boolean
```