### PR TITLE
Fix typo in test runner.

### DIFF
--- a/tests/test-portable.scm
+++ b/tests/test-portable.scm
@@ -24,7 +24,7 @@
           (display ". Expected ")
           (display (test-result-ref runner 'expected-value))
           (display ", got ")
-          (display (test-result-ref runner 'actual))
+          (display (test-result-ref runner 'actual-value))
           (display ".\n")))))
     (test-final
      (lambda (runner)


### PR DESCRIPTION
The property is called `actual-value` in SRFI 64, not `actual`. Thanks for merging.